### PR TITLE
Km/emitvalidation

### DIFF
--- a/App/src/routes/socketman/argument.svelte
+++ b/App/src/routes/socketman/argument.svelte
@@ -9,6 +9,16 @@
   export let argKey;
   let jsonCheck = false;
 
+  try {
+    if (typeof JSON.parse(argValue) === argType) {
+      jsonCheck = true;
+    } else {
+      jsonCheck = false;
+    }
+  } catch (error) {
+    jsonCheck = false;
+  }
+
   const onDelete = () => {
     console.log('onDelete called');
     //remove event is defined on index.svelte

--- a/App/src/routes/socketman/argument.svelte
+++ b/App/src/routes/socketman/argument.svelte
@@ -7,43 +7,36 @@
   export let argType;
   export let argValue;
   export let argKey;
-  let jsonCheck = false;
+  export let validJson;
 
-  try {
-    if (typeof JSON.parse(argValue) === argType) {
-      jsonCheck = true;
-    } else {
-      jsonCheck = false;
-    }
-  } catch (error) {
-    jsonCheck = false;
-  }
+  checkJson(argType, argValue);
 
-  const onDelete = () => {
-    console.log('onDelete called');
-    //remove event is defined on index.svelte
-    //everything inside second param is going to be in e.detail => see line 152 on index.svelte
-    dispatch('removeArg', { argKey });
-  };
-
-  const onChange = () => {
-    console.log('onChange called');
-
-    dispatch('changeArg', { argKey, argLabel, argType, argValue });
-  };
-
-  const onType = () => {
-    // each time this function is called, check if type of JSON result matches what the user said it would be
+  function checkJson(type, value) {
+    console.log(type, value);
     try {
-      if (typeof JSON.parse(argValue) === argType) {
-        jsonCheck = true;
+      if (typeof JSON.parse(value) === type) {
+        console.log(validJson);
+        console.log(typeof JSON.parse(value) === type);
+        validJson = true;
       } else {
-        jsonCheck = false;
+        console.log(validJson);
+        validJson = false;
+        console.log(validJson);
       }
     } catch (error) {
-      jsonCheck = false;
+      console.log(error);
+      validJson = false;
     }
-  };
+    onChange();
+  }
+
+  function onDelete() {
+    dispatch('removeArg', { argKey });
+  }
+
+  function onChange() {
+    dispatch('changeArg', { argKey, argLabel, argType, argValue, validJson });
+  }
 </script>
 
 <div class="argument-row">
@@ -54,23 +47,34 @@
     placeholder="Arg Label"
     autocomplete="off"
   />
-  <input
+  <select
     class="argument-type"
-    bind:value={argType}
-    on:change={onChange}
-    on:input={onType}
-    placeholder="Arg Type"
-    autocomplete="off"
-  />
+    value={argType}
+    on:change={(e) => {
+      argType = e.target.value;
+      onChange();
+      checkJson(argType, argValue);
+    }}
+  >
+    <option>string</option>
+    <option>number</option>
+    <option>boolean</option>
+    <option>null</option>
+    <option>object</option>
+    <option>array</option>
+    <option>undefined</option>
+  </select>
   <textarea
     class="argument-value"
     bind:value={argValue}
     on:change={onChange}
-    on:input={onType}
+    on:input={() => {
+      checkJson(argType, argValue);
+    }}
     placeholder="Enter a value using JSON"
     autocomplete="off"
   />
-  <div class={`json ${jsonCheck ? 'valid' : 'invalid'}`} />
+  <div class={`json ${validJson ? 'valid' : 'invalid'}`} />
   <button type="button" on:click={onDelete}>Delete</button>
 </div>
 

--- a/App/src/routes/socketman/argument.svelte
+++ b/App/src/routes/socketman/argument.svelte
@@ -9,12 +9,40 @@
   export let argKey;
   export let validJson;
 
+  // worth making a component that appears on mouseover. this will get big-ish in the current file
+  let errObj = {
+    header: '',
+    description: '',
+    expect: '',
+    actual: '',
+  };
+
   checkJson(argType, argValue);
 
   function checkJson(type, value) {
     console.log(type, value);
+
     try {
-      if (typeof JSON.parse(value) === type) {
+      // check array, obj, undefined, null
+      if (['array', 'object', 'null', 'undefined'].includes(type)) {
+        switch (type) {
+          case 'array':
+            validJson = value[0] === '[' && JSON.parse(value) ? true : false;
+            break;
+          case 'object':
+            validJson = value[0] === '{' && JSON.parse(value) ? true : false;
+            break;
+          case 'null':
+            validJson =
+              value === 'null' && JSON.parse(value) === null ? true : false;
+            break;
+          case 'undefined':
+            validJson = true;
+            break;
+        }
+      }
+      // check others
+      else if (typeof JSON.parse(value) === type) {
         console.log(validJson);
         console.log(typeof JSON.parse(value) === type);
         validJson = true;
@@ -52,7 +80,6 @@
     value={argType}
     on:change={(e) => {
       argType = e.target.value;
-      onChange();
       checkJson(argType, argValue);
     }}
   >
@@ -67,7 +94,6 @@
   <textarea
     class="argument-value"
     bind:value={argValue}
-    on:change={onChange}
     on:input={() => {
       checkJson(argType, argValue);
     }}

--- a/App/src/routes/socketman/argument.svelte
+++ b/App/src/routes/socketman/argument.svelte
@@ -71,7 +71,7 @@
   <input
     class="argument-label"
     bind:value={argLabel}
-    on:change={onChange}
+    on:input={onChange}
     placeholder="Arg Label"
     autocomplete="off"
   />

--- a/App/src/routes/socketman/index.svelte
+++ b/App/src/routes/socketman/index.svelte
@@ -111,6 +111,12 @@
 <section>
   <h1>Socketman Interface</h1>
 
+  <h3 id="emit-preview">
+    {`socket.emit(${Object.values($payloadArgsGlobal)
+      .map((el) => el.argLabel)
+      .join(', ')}${$callbackTFGlobal ? ', callback' : ''})`}
+  </h3>
+
   <!-- SOCKETMAN SECTION -->
   <form id="socketman" on:submit|preventDefault={sendMessage}>
     <div id="socketman-top">
@@ -245,5 +251,12 @@
   }
   .disabled {
     background-color: gray !important;
+  }
+  #emit-preview {
+    font-family: monospace;
+    color: rgb(255, 255, 255);
+    background-color: black;
+    padding: 5px;
+    font-weight: 400;
   }
 </style>

--- a/App/src/routes/socketman/index.svelte
+++ b/App/src/routes/socketman/index.svelte
@@ -22,27 +22,7 @@
     // create payloads array using argument strings parsed by json
     const payloads = Object.values($payloadArgsGlobal).map((el) => {
       if (!exitFlag) {
-        try {
-          if (typeof JSON.parse(el.argValue) === el.argType) {
-            return JSON.parse(el.argValue);
-          } else {
-            console.log(typeof JSON.parse(el.argValue), el.argType);
-            exitFlag = true;
-            if (!errMsg)
-              errMsg = `
-              TYPE MISMATCH \n
-              Expected : ${el.argType} \r
-              Parsed: ${typeof JSON.parse(el.argValue)}`;
-            return;
-          }
-        } catch (error) {
-          exitFlag = true;
-          if (!errMsg)
-            errMsg = `
-          INVALID JSON VALUE \n 
-          Value: ${el.argValue}`;
-          return;
-        }
+        return el.argType === 'undefined' ? undefined : JSON.parse(el.argValue);
       }
     });
 
@@ -193,7 +173,14 @@
       {/if}
     </div>
 
-    <button id="emit-btn" type="submit">Emit</button>
+    {#if Object.values($payloadArgsGlobal).reduce((sum, cur) => {
+      return cur.validJson ? 0 : sum + 1;
+    }, 0)}
+      <button id="emit-btn" class="disabled" type="button">Can't emit :(</button
+      >
+    {:else}
+      <button id="emit-btn" type="submit">Emit</button>
+    {/if}
   </form>
   <!-- bind:value - changes to the input value will update the connectTo value and changes to connectTo value will update input -->
 </section>
@@ -255,5 +242,8 @@
   }
   #emit-btn {
     background-color: green;
+  }
+  .disabled {
+    background-color: gray !important;
   }
 </style>

--- a/App/src/routes/socketman/index.svelte
+++ b/App/src/routes/socketman/index.svelte
@@ -81,6 +81,7 @@
           argValue: '',
           argType: '',
           argLabel: `arg${$argsCountGlobal + 1}`,
+          validJson: false,
         },
       };
     });
@@ -97,6 +98,7 @@
           argValue: e.detail.argValue,
           argType: e.detail.argType,
           argLabel: e.detail.argLabel,
+          validJson: e.detail.validJson,
         },
       };
     });
@@ -148,12 +150,13 @@
     <div id="argument-container">
       <!--  -->
       <!-- here we'll loop through our args and render them -->
-      {#each Object.keys($payloadArgsGlobal) as argument}
+      {#each Object.values($payloadArgsGlobal) as argument}
         <Argument
-          argLabel={$payloadArgsGlobal[argument].argLabel}
-          argType={$payloadArgsGlobal[argument].argType}
-          argValue={$payloadArgsGlobal[argument].argValue}
-          argKey={$payloadArgsGlobal[argument].argKey}
+          argLabel={argument.argLabel}
+          argType={argument.argType}
+          argValue={argument.argValue}
+          argKey={argument.argKey}
+          validJson={argument.validJson}
           on:changeArg={changeArg}
           on:removeArg={removeArg}
         />

--- a/App/src/routes/socketman/index.svelte
+++ b/App/src/routes/socketman/index.svelte
@@ -63,6 +63,9 @@
     allEventsGlobal.update((value) => {
       return [...value, eventObject];
     });
+
+    // temporary confirmation of success
+    alert('Event emitted successfully!');
   }
 
   function addArg(e) {

--- a/App/src/routes/socketman/index.svelte
+++ b/App/src/routes/socketman/index.svelte
@@ -130,7 +130,9 @@
   <h1>Socketman Interface</h1>
 
   <h3 id="emit-preview">
-    {`socket.emit(${Object.values($payloadArgsGlobal)
+    {`socket.emit(${$eventNameGlobal}${
+      Object.keys($payloadArgsGlobal).length ? ', ' : ''
+    }${Object.values($payloadArgsGlobal)
       .map((el) => el.argLabel)
       .join(', ')}${$callbackTFGlobal ? ', callback' : ''})`}
   </h3>


### PR DESCRIPTION
- Created dropdown for argtype
- Argtype and parsing now supports array vs object vs null (all objects), and undefined (not valid json)
- Undefined just ignores the value, so no parsing with this option
- Validation moved to pre-emit
- Flags on bad arguments, emit button gray and disabled if anything wrong
- Add emit preview string (“socket.emit(arg1, arg2, callback”) to socketman
- Quick add confirmation of successful emit (alert)
